### PR TITLE
Emojis in message reactions now show up in view!

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -58,6 +58,16 @@
         line-height: 1em;
     }
 
+    .message_reaction_emoji {
+        position: relative;
+        top: 1px;
+        font-size: 90%;
+        display: flex;
+        margin: 0 3px;
+        padding: 2px 0;
+        line-height: 1em;
+    }
+
     .message_reaction:hover .message_reaction_count {
         color: hsl(200, 100%, 40%);
     }

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -311,7 +311,7 @@
     top: 0;
     margin: 1px 3px;
     height: 17px;
-    width: 17px;
+    width: 0px;
     position: relative;
 }
 

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -304,6 +304,17 @@
     line-height: 1em;
 }
 
+.emojifixed {
+    display: inline-block;
+    flex-shrink: 0;
+    vertical-align: top;
+    top: 0;
+    margin: 1px 3px;
+    height: 17px;
+    width: 17px;
+    position: relative;
+}
+
 .typeahead .emoji {
     top: 2px;
 }

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -19,7 +19,7 @@
 
     <span class="alert-msg pull-right"></span>
 
-    <a class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">
+    <a href="{{ msg/url }}" class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">
         {{#unless include_sender}}
         <span class="copy-paste-text">&nbsp;</span>
         {{/unless}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -19,7 +19,7 @@
 
     <span class="alert-msg pull-right"></span>
 
-    <a href="{{ msg/url }}" class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">
+    <a class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">
         {{#unless include_sender}}
         <span class="copy-paste-text">&nbsp;</span>
         {{/unless}}

--- a/static/templates/message_reaction.hbs
+++ b/static/templates/message_reaction.hbs
@@ -4,7 +4,10 @@
     {{else if this.is_realm_emoji}}
         <img src="{{this.url}}" class="emoji" />
     {{else}}
-        <p><div class="emojifixed"></div>&#x{{this.emoji_code}};</p>
+        <p>
+            <div class="emojifixed"></div>
+            <div class="message_reaction_count">&#x{{this.emoji_code}}</div>
+        </p>
     {{/if}}
     <div class="message_reaction_count">{{this.vote_text}}</div>
 </div>

--- a/static/templates/message_reaction.hbs
+++ b/static/templates/message_reaction.hbs
@@ -4,7 +4,7 @@
     {{else if this.is_realm_emoji}}
         <img src="{{this.url}}" class="emoji" />
     {{else}}
-        <p>&#x{{this.emoji_code}};</p>
+        <p><div class="emojifixed"></div>&#x{{this.emoji_code}};</p>
     {{/if}}
     <div class="message_reaction_count">{{this.vote_text}}</div>
 </div>

--- a/static/templates/message_reaction.hbs
+++ b/static/templates/message_reaction.hbs
@@ -6,7 +6,7 @@
     {{else}}
         <p>
             <div class="emojifixed"></div>
-            <div class="message_reaction_count">&#x{{this.emoji_code}}</div>
+            <div class="message_reaction_emoji">&#x{{this.emoji_code}}</div>
         </p>
     {{/if}}
     <div class="message_reaction_count">{{this.vote_text}}</div>

--- a/static/templates/message_reaction.hbs
+++ b/static/templates/message_reaction.hbs
@@ -4,7 +4,7 @@
     {{else if this.is_realm_emoji}}
         <img src="{{this.url}}" class="emoji" />
     {{else}}
-        <div class="emoji emoji-{{this.emoji_code}}"></div>
+        <p>&#x{{this.emoji_code}};</p>
     {{/if}}
     <div class="message_reaction_count">{{this.vote_text}}</div>
 </div>


### PR DESCRIPTION
Fixes: Unicode emojis now show up in print view. We displayed the emojis in HTML view (which is able to print) rather than the custom Zulip way. This only impacts message reactions. Users are still able to add new emojis with the Zulip custom emoji collection and they are then converted to unicode to be displayed in HTML. Changes are made in html generated by handlebars and in the css to make sure formatting is uniform with surroundings.

**Screenshots and screen captures:**
![PNG image](https://user-images.githubusercontent.com/99095305/207169413-bcfd4b99-6584-4629-8586-ee4953905c00.png)
^^^ This is print view before the change. The graphics of the emojis are not shown in print view.
---
![PNG image](https://user-images.githubusercontent.com/99095305/207169291-44e28d3a-b21c-43bc-a287-477ef0b03651.png)
^^^ This is print view after the change. Emoji reactions now shows up in PDF form ready to be downloaded or printed.
---
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
