### PR TITLE
Page header does not overlap with text!

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -466,7 +466,7 @@
 
     .message-header-contents,
     .message_header_private_message .message-header-contents {
-        background-color: hsla(0, 0%, 0%, 0.2);
+        background-color: hsla(0, 0%, 0%, 0.2) !important;
         border-color: transparent;
     }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3300,4 +3300,58 @@ div.topic_edit_spinner .loading_indicator_spinner {
     a[href]:after {
         content: none !important;
     }
+
+    /* this is the one that actually makes the header stay */
+    .header {
+        position: relative;
+        z-index: 102; /* Needs to be higher than .alert-bar-container */
+        width: 100%;
+        height: $header_height;
+        padding-bottom: $header_padding_bottom;
+        background-color: inherit;
+    }
+
+    /* not working :( */
+    .message_area_padder {
+        /* The height of the header and the message_view_header plus a small gap */
+        margin-top: 0px;
+        overflow: visible;
+    }
+
+    /* not working :( */
+    .message_list {
+        .recipient_row {
+            border-bottom: 1px solid hsl(0, 0%, 88%);
+            margin-bottom: 0px;
+        }
+    }
+
+    /* not working :( */
+    #message_view_header_underpadding {
+        position: relative;
+        width: 100%;
+        top: $header_height;
+        height: $header_padding_bottom;
+        z-index: 99;
+    }
+
+    /* not working :( */
+    div.floating_recipient {
+        content: none !important;
+    }
+
+    /* not working :( */
+    .floating_recipient {
+        .recipient_row {
+            content: none !important;
+        }
+    
+        .recipient_row_date.hide-date {
+            content: none !important;
+        }
+    
+        .message_header_private_message {
+            content: none !important;
+        }
+    }
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3301,7 +3301,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
         content: none !important;
     }
 
-    /* this is the one that actually makes the header stay */
+    /* this is the one that makes the header stay on top and messages not overlap with it */
     .header {
         position: relative;
         z-index: 102; /* Needs to be higher than .alert-bar-container */
@@ -3309,49 +3309,5 @@ div.topic_edit_spinner .loading_indicator_spinner {
         height: $header_height;
         padding-bottom: $header_padding_bottom;
         background-color: inherit;
-    }
-
-    /* not working :( */
-    .message_area_padder {
-        /* The height of the header and the message_view_header plus a small gap */
-        margin-top: 0px;
-        overflow: visible;
-    }
-
-    /* not working :( */
-    .message_list {
-        .recipient_row {
-            border-bottom: 1px solid hsl(0, 0%, 88%);
-            margin-bottom: 0px;
-        }
-    }
-
-    /* not working :( */
-    #message_view_header_underpadding {
-        position: relative;
-        width: 100%;
-        top: $header_height;
-        height: $header_padding_bottom;
-        z-index: 99;
-    }
-
-    /* not working :( */
-    div.floating_recipient {
-        content: none !important;
-    }
-
-    /* not working :( */
-    .floating_recipient {
-        .recipient_row {
-            content: none !important;
-        }
-    
-        .recipient_row_date.hide-date {
-            content: none !important;
-        }
-    
-        .message_header_private_message {
-            content: none !important;
-        }
     }
 }


### PR DESCRIPTION
Fixes: Here, we changed the position of the header during print view so that if you scroll down, the header would not overlap with the messages. We also made it so that links do not show up in full on print view. This restored the time stamp of the messages as well. 

**Screenshots and screen captures:**
![Screen Shot 2022-12-13 at 6 51 09 PM](https://user-images.githubusercontent.com/99095305/207470327-61227813-d9c3-4e2e-b884-34bca8807ea4.jpeg)
^^^ This was before the overlap was fixed. When you are printing a page that is scrolled down, the messages would overlap with the header. 
---
<img width="498" alt="Screen Shot 2022-12-13 at 6 49 00 PM" src="https://user-images.githubusercontent.com/99095305/207470115-c6c4c1cf-7820-403d-8255-80a6cf870298.png">
^^^ This is a picture after the overlap is fixed. There are some overlap problems with the floating message header, but they could not be addressed in this commit. 
---
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
